### PR TITLE
Small fixes feedback on 07/12

### DIFF
--- a/aises_6_2
+++ b/aises_6_2
@@ -297,6 +297,8 @@ the problem of figuring out how to act, given the range of differing
 views on ethics. A solution from the moral uncertainty literature which
 best embodies the democratic ideal is the <em>moral parliament</em>
 approach, which we will discuss later in this chapter.</p>
+
+<br>
 <div class="visionbox">
 <legend class="visionboxlegend">
     <p><span><b>A Note On The Three Laws of Robotics</b></span></p>
@@ -351,6 +353,8 @@ behavior in AI systems, even if they serve as a useful starting point
 for examining certain questions and problems in AI safety.<p>
 </p>
 </div>
+<br>
+
 <h3 id="conclusions-about-law">Conclusions About Law</h3>
 <p>The law is comprehensive, but not comprehensive enough to ensure that
 the actions of an AI system are safe and beneficial. AI systems must

--- a/aises_6_4
+++ b/aises_6_4
@@ -178,6 +178,8 @@ we will revisit introductory concepts from economics to examine the case
 that AIs (developed in accordance with market incentives) can create
 widespread benefits by improving efficiency and growth.<p>
 </p>
+
+<br>
 <div class="visionbox">
 <legend class="visionboxlegend">
     <p><span><b>A Note on Gains from Trade</b></span></p>
@@ -203,6 +205,9 @@ if Alice focuses on coconuts and Bob on fishing. In most cases, trading
 makes people better off. One role of the economy is to enable such
 trades on a large scale.</p>
 </div>
+
+<br>
+
 <h4
 id="markets-coordinate-trade-allowing-gains-from-specialization.">Markets
 coordinate trade, allowing gains from specialization.</h4>
@@ -1420,7 +1425,8 @@ wellbeing, such as crime rates and physical health. As we move forward,
 we should take care to ensure that AIs’ potential is used to serve
 humanity, not just the economy.<p>
 </p>
-<div class="storybox">
+<br>
+<div class="visionbox">
 <legend class="visionboxlegend">
     <p><span><b>A Note on Wellbeing in Social Science</b></span></p>
 </legend>

--- a/aises_6_6
+++ b/aises_6_6
@@ -216,6 +216,8 @@ this knowledge, one approach to using AI to increase happiness is to
 focus on increasing some of these; for instance, we might use AIs to
 develop better tools to improve healthcare, increase literacy rates, and
 create more interesting and fulfilling jobs.</p>
+
+<br>
 <div class="visionbox">
 <legend class="visionboxlegend">
 <p><span><b>A Note on Measuring Wellbeing</b></span></p>
@@ -275,6 +277,8 @@ QALYs, DALYs, and WELBYs provide different approximations of wellbeing
 that can be used to inform high-level decision-making and
 policy-setting.</p>
 </div>
+<br>
+
 <h2 id="problems-for-happiness-focused-machine-ethics">6.6.2 Problems for
 Happiness-Focused Machine Ethics</h2>
 <h4 id="happiness-is-a-subjective-experience.">Happiness is a subjective
@@ -338,6 +342,7 @@ which should also be on the list. However, if goods such as autonomy and
 happiness play such a filtering role for the objective goods theorist,
 it is unclear whether there are truly a variety of objective goods
 left.</p>
+<br>
 <div class="visionbox">
 <legend class="visionboxlegend">
     <p><span><b>A Note on Digital Minds</b></span></p>
@@ -448,6 +453,7 @@ still considered an alignment failure, precisely because it may be
 incentivized to behave in ways that do not align with positive human
 values and preferences.</p>
 </div>
+<br>
 <h3 id="conclusions-about-happiness">Conclusions About Happiness</h3>
 <h4 id="summary.">Summary.</h4>
 <p>In this section, we explored the general approach of using AI systems

--- a/aises_8_4
+++ b/aises_8_4
@@ -1452,6 +1452,8 @@ to achieve their goals. AI collective intelligences would be vastly
 superior to human collective intelligences, and as a consequence, humans
 may be prevented from participating in and understanding the decisions
 AIs make within such systems.</p>
+
+<br>
 <div class="visionbox">
 <legend class="visionboxlegend">
     <p><span><b>A Note on Morality as Cooperation</b></span></p>
@@ -1524,6 +1526,7 @@ theft</td>
 </table>
 </div>
 <br>
+
 <p><strong>Kinship.</strong> Natural selection can favor agents who
 cooperate with their genetic relatives. This is because there may be
 copies of these agents’ genes in their relatives’ genomes, and so

--- a/aises_8_4
+++ b/aises_8_4
@@ -435,7 +435,7 @@ US’s entry into WWII.<p>
 
 <br>
 <table class="tableLayout">
-<caption style="overflow: hidden; white-space: nowrap;">Table 8.6: A pay-off matrix for competitors choosing whether to defend or preemptively attack.</caption>
+<caption style="overflow: hidden; white-space: nowrap;">Table 8.6: A pay-off matrix for competitors choosing whether <br> to defend or preemptively attack.</caption>
 <thead>
 <tr class="header">
 <th style="text-align: left;"></th>
@@ -578,6 +578,7 @@ information with the intent to deceive or manipulate others. Both of
 these types of information problem can cause bargains to fail,
 generating conflict.</p>
 <br>
+<div id="tab:distinguish">
 <table class="tableLayout">
 <thead>
 <tr class="header">
@@ -602,6 +603,7 @@ class="math inline"><em>b</em>(1−<em>a</em>)</span></td>
 </tr>
 </tbody>
 </table>
+</div>
 <br>
 <p>The term <span class="math inline"><em>a</em></span> is the
 probability of a player knowing the strategy of its partner. Relevant


### PR DESCRIPTION
- Restyled table 8.6 - broke up caption which should allow for better centering (rather than increasing table spread)
- _A note on wellbeing in social science_ should now correctly span the box
- Readded whitespace surrounding visionboxes in sections that were replaced 